### PR TITLE
use the `i` flag for `feedkeys()` to allow mapping with fixed replacement motion

### DIFF
--- a/autoload/subversive/doubleMotion.vim
+++ b/autoload/subversive/doubleMotion.vim
@@ -97,7 +97,7 @@ function! subversive#doubleMotion#selectTextMotion(type, ...)
 
     call s:UpdateHighlight(s:searchText, start[1], start[1], start[2], end[2], 1, s:completeWord)
 
-    call feedkeys("\<plug>(_SubversiveSubstituteRangeSecondary)", "m")
+    call feedkeys("\<plug>(_SubversiveSubstituteRangeSecondary)", "mi")
 endfunction
 
 function! s:RestoreStartCursorPosition()


### PR DESCRIPTION
In order to make this mapping work

```viml
nmap <silent> <leader>rw :<c-u>call subversive#doubleMotion#preSubstitute(v:register, 1, 0, 1, 0)<cr>:set opfunc=subversive#doubleMotion#selectTextMotion<cr>g@iwae  
```

I made the `feedkeys()` mapping get executed before the rest of the mapped keys.

I guess it's not unlikely to break something else, so could you have a look?