### PR TITLE
bugfix: #9

### DIFF
--- a/autoload/subversive/doubleMotion.vim
+++ b/autoload/subversive/doubleMotion.vim
@@ -186,7 +186,7 @@ function! subversive#doubleMotion#selectRangeMotion(type)
                 let fullCommand .= escape(s:searchText, '/\')
             endif
 
-            call feedkeys(fullCommand, "t")
+            call feedkeys(fullCommand, "tn")
         else
             let replaceText = input('Substitute With: ', (g:subversivePromptWithCurrent ? s:searchText : ''))
 


### PR DESCRIPTION
From the vim doc:
```vim
feedkeys({string} [, {mode}])				*feedkeys()*
		Characters in {string} are queued for processing as if they
		come from a mapping or were typed by the user.
                " [....]
		'n'	Do not remap keys.
```

If the user is using the following mapping:
```vim
nnoremap : ;
```

The `feedkeys` wont use the remap. 